### PR TITLE
Remove binary compatability with older versions of Windows.

### DIFF
--- a/ErrorMode.xs
+++ b/ErrorMode.xs
@@ -1,3 +1,6 @@
+#define WINVER 0x0603
+#define _WIN32_WINNT 0x0603
+
 #include "EXTERN.h"
 #include "perl.h"
 #include "XSUB.h"
@@ -6,89 +9,19 @@
 #include <windows.h>
 
 /*
- * So it begins...
- *
- * - SetErrorMode() was introduced in XP / 2003
- *   we assume you are using at least XP / 2003
- *
- * - GetErrorMode() was introduced in Vista / 2008
- *   but apparently isn't supported by the version
- *   of Strawberry or MSVC++ that I am testing with
- *   (it does work with cygwin 64 that I am using
- *   I didn't try Strawberry 64, maybe it is a 32
- *   bit problem).  It can also be emulated using
- *   SetErrorMode(), although there is a race
- *   condition if you are using threads (including
- *   forking since this is windows).
- *   Thus:
- *     1. if GetErrorMode() is found dynamically
- *        using GetProcAddress() in kernel32.dll
- *        we use that.
- *     2. if not we emulate it using SetErrorMode()
- *     3. if there is an error resolving the symbol
- *        then we also use the GetErrorMode()
- *        emulation.
- *   This way we maintain binary compatability back
- *   To Windows XP / 2003, and we don't have the
- *   race condition for GetErrorMode() when forking
- *   on Vista / 2008 or better.
- *
- * - GetThreadErrorMode() and SetThreadErrorMode()
- *   are considered "safer" since they get/set the
- *   error mode only on the current thread.  However
- *   they are also only available on Windows 7 and
- *   newer.  So we provode them, once again
- *   dynamically, if they are available.  Since
- *   no emulation is possible we throw a "not
- *   implemented" exception if they are not found.
- *   We still maintain binary compat with XP / 2003.
+ * This XS used to have binary compat back to
+ * Windows XP / 2003 thru Vista, but support
+ * for those operating systems has been ended
+ * years and years ago so I am removing it
+ * @plicease 5/6/2021
  */
 
-typedef UINT  (__stdcall *GetErrorMode_t)      (void);
-typedef DWORD (__stdcall *GetThreadErrorMode_t)(void);
-typedef BOOL  (__stdcall *SetThreadErrorMode_t)(DWORD,LPDWORD);
-
-static UINT __stdcall FallbackGetErrorMode(void)
-{
-  UINT old;
-  old = SetErrorMode(0);
-  SetErrorMode(old);
-  return old;
-}
-
-static GetErrorMode_t       myGetErrorMode       = NULL;
-static GetThreadErrorMode_t myGetThreadErrorMode = NULL;
-static SetThreadErrorMode_t mySetThreadErrorMode = NULL;
-
-static void
-win32_error_mode_boot()
-{
-  HMODULE mod;
-
-  mod = LoadLibrary("kernel32.dll");
-
-  if(mod != NULL)
-    myGetErrorMode = (GetErrorMode_t) GetProcAddress(mod, "GetErrorMode");
-
-  if(myGetErrorMode == NULL)
-    myGetErrorMode = &FallbackGetErrorMode;
-
-  if(mod == NULL)
-    return;
-
-  myGetThreadErrorMode = (GetThreadErrorMode_t) GetProcAddress(mod, "GetThreadErrorMode");
-  mySetThreadErrorMode = (SetThreadErrorMode_t) GetProcAddress(mod, "SetThreadErrorMode");
-}
-
 MODULE = Win32::ErrorMode PACKAGE = Win32::ErrorMode
-
-BOOT:
-    win32_error_mode_boot();
 
 unsigned int
 GetErrorMode()
   CODE:
-    RETVAL = myGetErrorMode();
+    RETVAL = GetErrorMode();
   OUTPUT:
     RETVAL
 
@@ -99,9 +32,7 @@ SetErrorMode(mode)
 unsigned int
 GetThreadErrorMode()
   CODE:
-    if(myGetThreadErrorMode == NULL)
-      croak("not implemented");
-    RETVAL = myGetThreadErrorMode();
+    RETVAL = GetThreadErrorMode();
   OUTPUT:
     RETVAL
 
@@ -112,26 +43,10 @@ SetThreadErrorMode(mode)
     DWORD old;
     BOOL ok;
   CODE:
-    if(mySetThreadErrorMode == NULL)
-      croak("not implemented");
-    ok = mySetThreadErrorMode(mode, &old);
+    ok = SetThreadErrorMode(mode, &old);
     if(!ok)
       croak("error setting thread error mode");
     RETVAL = old;
-  OUTPUT:
-    RETVAL
-
-int
-_has_real_GetErrorMode()
-  CODE:
-    RETVAL = myGetErrorMode != &FallbackGetErrorMode;
-  OUTPUT:
-    RETVAL
-
-int
-_has_thread()
-  CODE:
-    RETVAL = myGetThreadErrorMode != NULL && mySetThreadErrorMode != NULL;
   OUTPUT:
     RETVAL
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Tie interface thread:
 use if $^O eq 'MSWin32', 'Win32::ErrorMode';
 
 # 0x3 = SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX
-local $Win32::ErrorMode::ThreadErrorMode = 0x3; 
+local $Win32::ErrorMode::ThreadErrorMode = 0x3;
 
 system "program_that_would_normal_produce_an_error_dialog.exe";
 ```
@@ -72,10 +72,10 @@ This module also provides a tied interface `$ErrorMode` and
 SetErrorMode($mode);
 ```
 
-Controls whether Windows will handle the specified type of serious errors 
+Controls whether Windows will handle the specified type of serious errors
 or whether the process will handle them.
 
-`$mode` can be zero or more of the following values, bitwise or'd 
+`$mode` can be zero or more of the following values, bitwise or'd
 together:
 
 - SEM\_FAILCRITICALERRORS
@@ -125,7 +125,7 @@ or newer.
 # CAVEATS
 
 `GetErrorMode` was introduced in Windows Vista / 2008, but will be
-emulated on XP using `SetErrorMode`, but there may be a race 
+emulated on XP using `SetErrorMode`, but there may be a race
 condition if you are using threads / forking as the emulation
 temporarily sets the error mode.  Then again there is probably a
 race condition anyway since you are using the global version in a

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX);
 system "program_that_would_normal_produce_an_error_dialog.exe";
 ```
 
-If you are using Windows 7 or better:
+Using the thread interface (preferred):
 
 ```perl
 use Win32::ErrorMode qw( :all );
@@ -57,9 +57,7 @@ with missing symbols or .dll files.  This is useful when you have
 a long running process or a test suite where such failures are
 expected, or part of the configuration process.
 
-It may have other applications.  It also attempts to smooth over
-the variously incompatible versions of Windows while maintaining
-binary compatibility.
+It may have other applications.
 
 This module also provides a tied interface `$ErrorMode` and
 `$ThreadErrorMode`.
@@ -109,8 +107,7 @@ SetThreadErrorMode($mode);
 ```
 
 Same as ["SetErrorMode"](#seterrormode) above, except it only changes the error mode
-on the current thread.  Only available when running under Windows 7 or
-newer.
+on the current thread.
 
 ## GetThreadErrorMode
 
@@ -119,18 +116,19 @@ my $mode = GetThreadErrorMode();
 ```
 
 Same as ["GetErrorMode"](#geterrormode) above, except it only gets the error mode
-for the current thread.  Only available when running under Windows 7
-or newer.
+for the current thread.
 
 # CAVEATS
 
-`GetErrorMode` was introduced in Windows Vista / 2008, but will be
-emulated on XP using `SetErrorMode`, but there may be a race
-condition if you are using threads / forking as the emulation
-temporarily sets the error mode.  Then again there is probably a
-race condition anyway since you are using the global version in a
-threaded application, but you should keep this in mind if you must
-support old versions of Windows.
+All of these functions are available in the oldest supported version
+of Windows, which is 8.1.  Previous versions of this module would use
+dynamic loading and emulation to support some or all of the functions
+on older and newer systems, while maintaining binary compatibility
+back to Windows XP.  Older versions could throw and exception for
+the threaded interface on older Windows systems.  As of 0.07 the
+compatibility code has been removed: this module will only install
+and function on Windows 8.1 and later and all functions are fully
+supported.
 
 # SEE ALSO
 

--- a/dist.ini
+++ b/dist.ini
@@ -15,12 +15,6 @@ workflow = windows
 workflow = cygwin
 workflow = msys2-mingw
 
-diag_preamble = | $post_diag = sub {
-diag_preamble = |   use Win32::ErrorMode;
-diag_preamble = |   diag "has real GetErrorMode = ", Win32::ErrorMode::_has_real_GetErrorMode();
-diag_preamble = |   diag "has thread variant    = ", Win32::ErrorMode::_has_thread();
-diag_preamble = | };
-
 [RemovePrereqs]
 remove = strict
 remove = warnings

--- a/lib/Win32/ErrorMode.pm
+++ b/lib/Win32/ErrorMode.pm
@@ -22,7 +22,7 @@ use constant {
  
  system "program_that_would_normal_produce_an_error_dialog.exe";
 
-If you are using Windows 7 or better:
+Using the thread interface (preferred):
 
  use Win32::ErrorMode qw( :all );
  
@@ -60,9 +60,7 @@ with missing symbols or .dll files.  This is useful when you have
 a long running process or a test suite where such failures are
 expected, or part of the configuration process.
 
-It may have other applications.  It also attempts to smooth over
-the variously incompatible versions of Windows while maintaining
-binary compatibility.
+It may have other applications.
 
 This module also provides a tied interface C<$ErrorMode> and
 C<$ThreadErrorMode>.
@@ -126,26 +124,26 @@ Retrieves the error mode for the current process.
  SetThreadErrorMode($mode);
 
 Same as L</SetErrorMode> above, except it only changes the error mode
-on the current thread.  Only available when running under Windows 7 or
-newer.
+on the current thread.
 
 =head2 GetThreadErrorMode
 
  my $mode = GetThreadErrorMode();
 
 Same as L</GetErrorMode> above, except it only gets the error mode
-for the current thread.  Only available when running under Windows 7
-or newer.
+for the current thread.
 
 =head1 CAVEATS
 
-C<GetErrorMode> was introduced in Windows Vista / 2008, but will be
-emulated on XP using C<SetErrorMode>, but there may be a race
-condition if you are using threads / forking as the emulation
-temporarily sets the error mode.  Then again there is probably a
-race condition anyway since you are using the global version in a
-threaded application, but you should keep this in mind if you must
-support old versions of Windows.
+All of these functions are available in the oldest supported version
+of Windows, which is 8.1.  Previous versions of this module would use
+dynamic loading and emulation to support some or all of the functions
+on older and newer systems, while maintaining binary compatibility
+back to Windows XP.  Older versions could throw and exception for
+the threaded interface on older Windows systems.  As of 0.07 the
+compatibility code has been removed: this module will only install
+and function on Windows 8.1 and later and all functions are fully
+supported.
 
 =head1 SEE ALSO
 

--- a/t/00_diag.t
+++ b/t/00_diag.t
@@ -14,11 +14,7 @@ $modules{$_} = $_ for qw(
   Test2::V0
 );
 
-$post_diag = sub {
-  use Win32::ErrorMode;
-  diag "has real GetErrorMode = ", Win32::ErrorMode::_has_real_GetErrorMode();
-  diag "has thread variant    = ", Win32::ErrorMode::_has_thread();
-};
+
 
 my @modules = sort keys %modules;
 

--- a/t/win32_errormode.t
+++ b/t/win32_errormode.t
@@ -14,9 +14,6 @@ subtest 'basic' => sub {
 };
 
 subtest 'thread' => sub {
-  skip_all 'test requires working GetThreadErrorMode and SetThreadErrorMode'
-    unless Win32::ErrorMode::_has_thread();
-
   my $mode = GetThreadErrorMode();
   note "mode = $mode\n";
   like $mode, qr{^[0-9]+$}, "mode looks like an integer";


### PR DESCRIPTION
We only support Windows 8.1+ as earlier versions are not supported by Microsoft.